### PR TITLE
Make RxBluetooth & BluetoothConnection final.

### DIFF
--- a/rxbluetooth/src/main/java/com/github/ivbaranov/rxbluetooth/BluetoothConnection.java
+++ b/rxbluetooth/src/main/java/com/github/ivbaranov/rxbluetooth/BluetoothConnection.java
@@ -33,7 +33,7 @@ import java.util.List;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
-public class BluetoothConnection {
+public final class BluetoothConnection {
 
   private static final String TAG = BluetoothConnection.class.getName();
 

--- a/rxbluetooth/src/main/java/com/github/ivbaranov/rxbluetooth/RxBluetooth.java
+++ b/rxbluetooth/src/main/java/com/github/ivbaranov/rxbluetooth/RxBluetooth.java
@@ -55,7 +55,7 @@ import static android.os.Build.VERSION.SDK_INT;
 /**
  * Enables clients to listen to bluetooth events using RxJava Observables.
  */
-public class RxBluetooth {
+public final class RxBluetooth {
   private BluetoothAdapter bluetoothAdapter;
   private Context context;
 


### PR DESCRIPTION
Personally, I'd make them final although I can imagine some consumers are using this library directly rather through an interface and hence relying on the fact that they can use Mockito and mock it. On the other hand, Mockito also supports mocking final classes now if you opt in.