### PR TITLE
Fix Travis build by using jcenter last.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,8 @@
 buildscript {
   repositories {
-    jcenter()
     google()
+    mavenCentral()
+    jcenter()
   }
   dependencies {
     classpath "com.android.tools.build:gradle:$GRADLE_PLUGIN_VERSION"
@@ -11,8 +12,9 @@ buildscript {
 
 allprojects {
   repositories {
-    jcenter()
     google()
+    mavenCentral()
+    jcenter()
   }
 }
 


### PR DESCRIPTION
jcenter is often flaky and ideally, it should not be used (there are some transitive dependencies from Android Gradle Plugin which are only on jcenter so we still need it for the time being). Lint dependencies are on `google()` as well and for almost everything else we can use `mavenCentral()`. This should make Travis go green again.