### PR TITLE
Add RxBluetooth#connectAsClient with RFCOMM channel id.

### DIFF
--- a/rxbluetooth/src/main/java/com/github/ivbaranov/rxbluetooth/Utils.java
+++ b/rxbluetooth/src/main/java/com/github/ivbaranov/rxbluetooth/Utils.java
@@ -1,16 +1,34 @@
 package com.github.ivbaranov.rxbluetooth;
 
+import android.bluetooth.BluetoothDevice;
+import android.bluetooth.BluetoothSocket;
 import java.io.Closeable;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 
 final class Utils {
-  static void close(Closeable closeable) {
+  static void close(final Closeable closeable) {
     if (closeable != null) {
       try {
         closeable.close();
       } catch (IOException ignored) {
         // Ignored.
       }
+    }
+  }
+
+  @SuppressWarnings("unchecked") static BluetoothSocket createRfcommSocket(
+      final BluetoothDevice device, final int channel) {
+    try {
+      Method method = BluetoothDevice.class.getMethod("createRfcommSocket", Integer.TYPE);
+      return (BluetoothSocket) method.invoke(device, channel);
+    } catch (final NoSuchMethodException e) {
+      throw new UnsupportedOperationException(e);
+    } catch (final InvocationTargetException e) {
+      throw new UnsupportedOperationException(e);
+    } catch (final IllegalAccessException e) {
+      throw new UnsupportedOperationException(e);
     }
   }
 


### PR DESCRIPTION
This seems to be common practice that sometimes you have to go through the RFCOMM channel directly by using reflection and accessing one of the hidden methods.

Unfortunately, I'm also forced to do this with the device I'm talking to. Hence it would be nice if the library offered this but warns that this might not work in the future.