### PR TITLE
Fix delimiter check.

### DIFF
--- a/rxbluetooth/src/main/java/com/github/ivbaranov/rxbluetooth/BluetoothConnection.java
+++ b/rxbluetooth/src/main/java/com/github/ivbaranov/rxbluetooth/BluetoothConnection.java
@@ -153,7 +153,7 @@ public final class BluetoothConnection {
             }
 
             if (found) {
-              if (!delimitersMatched()) {
+              if (delimitersMatched()) {
                 emit();
               }
             } else {


### PR DESCRIPTION
Dunno how this went unnoticed. Maybe, I'm also overseeing something though.

I'm only having one delimiter `\r`; and in that case when it emit's I'm getting two messages combined instead of each separately.